### PR TITLE
Add links to hosted demos to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You could run demos from [GitHub Pages for this repository.](https://intel.githu
 
 ## Demos description
 
-### [Punchmeter](punchmeter)
+### [Punchmeter](https://intel.github.io/generic-sensor-demos/punchmeter/) ([code](punchmeter))
 
 Punchmeter is a simple application that calculates user's punch speed using
 LinearAcceleration sensor. To try it the user should make a punch holding
@@ -48,7 +48,7 @@ mobile device in his/her hand.
 
 ---
 
-### [Orientation phone](orientation-phone)
+### [Orientation phone](https://intel.github.io/generic-sensor-demos/orientation-phone/) ([code](orientation-phone))
 
 This simple demo illustrates how an absolute orientation sensor can be used to
 modify rotation quaternion of a 3D model. The <code>model</code> is a three.js
@@ -60,7 +60,7 @@ property.
 
 ---
 
-### [360 degree beach panorama demo](websensor-panorama)
+### [360 degree beach panorama demo](https://intel.github.io/generic-sensor-demos/websensor-panorama/) ([code](websensor-panorama))
 
 The demo presents a 360 degree panorama view of a beach with an added sound effect.
 The user can look around the scene by moving their device.
@@ -70,7 +70,7 @@ The demo uses the orientation sensor to enable the user to look around.
 
 ---
 
-### [360 degree video demo](websensor-video)
+### [360 degree video demo](https://intel.github.io/generic-sensor-demos/websensor-video/) ([code](websensor-video))
 
 This demo presents a 360 degree video that the user can look around by moving their device.
 The user can also play the video in both forward and reverse by holding the device and walking
@@ -80,7 +80,7 @@ walking detection to enable the user to control video playback by walking.
 
 ---
 
-### [Ambient Map demo](ambient-map/build/bundled)
+### [Ambient Map demo](https://intel.github.io/generic-sensor-demos/ambient-map/build/bundled/) ([code](ambient-map/build/bundled))
 
 This web application demonstrates how Ambient light sensor can be used to control style of a map widget.
 When ambient illuminance level is less than 10 lumen, night mode style will be used.
@@ -93,7 +93,7 @@ flag set.
 
 ---
 
-### [Sensor Info demo](sensor-info/build/bundled)
+### [Sensor Info demo](https://intel.github.io/generic-sensor-demos/sensor-info/build/bundled/) ([code](sensor-info/build/bundled))
 
 This web application presents information about device sensors and their reading values.
 
@@ -105,7 +105,7 @@ flag set.
 
 ---
 
-### [VR Button demo](vr-button/build/bundled)
+### [VR Button demo](https://intel.github.io/generic-sensor-demos/vr-button/build/bundled/) ([code](vr-button/build/bundled))
 
 This web application demonstrates how Magnetometer sensor can be used to provide user input for WebVR
 content. If you have VR enclosure with magnet button, you can interact with objects in the scene by


### PR DESCRIPTION
I feel this makes access to demos easier. I observe you have the links in https://intel.github.io/generic-sensor-demos/ but having them linked from the README direct won't hurt.

PTAL @alexshalamov @pozdnyakov 