### PR TITLE
Add RelativeOrientationSensor test

### DIFF
--- a/sensor-tester/src/sensor-tests-page.js
+++ b/sensor-tester/src/sensor-tests-page.js
@@ -120,21 +120,13 @@ class SensorTestsPage extends LitElement {
      *
      * @param {array|number} val Actual reading values.
      * @param {array|number} exp expected reading values.
-     * @param {number} eps The allowable epsilon against expected values.
-     * @param {string} cmp Comparision type: "min"/"max"/"absolute".
+     * @param {Function} isEqual Function which compares the reading values
+     *                           and return a boolean result.
      */
-    const compareReadings = (val, exp, eps, cmp = '') => {
+    const compareReadings = (val, exp, isEqual) => {
       // compare number values
       if (typeof val === 'number' && typeof exp === 'number') {
-        if (cmp === 'min') {
-          return val >= exp;
-        }
-        else if (cmp === 'max') {
-          return val <= exp;
-        }
-        else {
-          return Math.abs(val - exp) < eps;
-        }
+        return isEqual(val, exp);
       }
       // compare array values
       else if (val instanceof Array && exp instanceof Array) {
@@ -142,10 +134,7 @@ class SensorTestsPage extends LitElement {
           return false;
         }
         for (const [index, value] of val.entries()) {
-          if (!compareReadings(Math.abs(value), Math.abs(exp[index]), eps) && cmp === 'absolute') {
-            return false;
-          }
-          else if (!compareReadings(value, exp[index], eps)) {
+          if (!compareReadings(value, exp[index], isEqual)) {
             return false;
           }
         }
@@ -158,7 +147,7 @@ class SensorTestsPage extends LitElement {
     // if sensor value is same as expectation, pass test
     this.items[index].handler = () => {
       if (Object.keys(item.expected).every(
-          key => compareReadings(this.sensor[key], item.expected[key], item.epsilon, item.comparison))) {
+          key => compareReadings(this.sensor[key], item.expected[key], eval(item.isEqual)))) {
           this.testPassed(index);
       }
     }

--- a/sensor-tester/src/tests/absoluteorientationsensor.json
+++ b/sensor-tester/src/tests/absoluteorientationsensor.json
@@ -5,6 +5,6 @@
       "illustration": "src/tests/absoluteorien_+Y_north.png",
       "duration":     5,
       "expected":     { "quaternion": [0, 0, 0, 1.0] },
-      "epsilon":      0.1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 0.1"
     }
 ]

--- a/sensor-tester/src/tests/accelerometer-screen.json
+++ b/sensor-tester/src/tests/accelerometer-screen.json
@@ -5,7 +5,7 @@
       "illustration": "src/tests/accel_+z_gravity.png",
       "duration":     3,
       "expected":     { "x": 0, "y": 0, "z": 9.8 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test web page -Z gravity",
@@ -13,7 +13,7 @@
       "illustration": "src/tests/accel_-z_gravity.png",
       "duration":     4,
       "expected":     { "x": 0, "y": 0, "z": -9.8 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test web page +X gravity",
@@ -21,7 +21,7 @@
       "illustration": "src/tests/accel_+x_gravity.png",
       "duration":     3,
       "expected":     { "x": 9.8, "y": 0, "z": 0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test web page -X gravity",
@@ -29,7 +29,7 @@
       "illustration": "src/tests/accel_-x_gravity.png",
       "duration":     3,
       "expected":     { "x": -9.8, "y": 0, "z": 0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test web page +Y gravity",
@@ -37,7 +37,7 @@
       "illustration": "src/tests/accel_+y_gravity.png",
       "duration":     4,
       "expected":     { "x": 0, "y": 9.8, "z": 0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test web page -Y gravity",
@@ -45,7 +45,7 @@
       "illustration": "src/tests/accel_-y_gravity.png",
       "duration":     4,
       "expected":     { "x": 0, "y": -9.8, "z": 0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test web page +X acceleration",
@@ -53,7 +53,7 @@
       "illustration": "src/tests/accel_+x_acceleration.gif",
       "duration":     5,
       "expected":     { "x": 3.0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test web page -X acceleration",
@@ -61,6 +61,6 @@
       "illustration": "src/tests/accel_-x_acceleration.gif",
       "duration":     5,
       "expected":     { "x": -3.0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     }
 ]

--- a/sensor-tester/src/tests/accelerometer.json
+++ b/sensor-tester/src/tests/accelerometer.json
@@ -5,7 +5,7 @@
       "illustration": "src/tests/accel_+z_gravity.png",
       "duration":     3,
       "expected":     { "x": 0, "y": 0, "z": 9.8 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test -Z gravity",
@@ -13,7 +13,7 @@
       "illustration": "src/tests/accel_-z_gravity.png",
       "duration":     4,
       "expected":     { "x": 0, "y": 0, "z": -9.8 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test +X gravity",
@@ -21,7 +21,7 @@
       "illustration": "src/tests/accel_+x_gravity.png",
       "duration":     3,
       "expected":     { "x": 9.8, "y": 0, "z": 0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test -X gravity",
@@ -29,7 +29,7 @@
       "illustration": "src/tests/accel_-x_gravity.png",
       "duration":     3,
       "expected":     { "x": -9.8, "y": 0, "z": 0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test +Y gravity",
@@ -37,7 +37,7 @@
       "illustration": "src/tests/accel_+y_gravity.png",
       "duration":     4,
       "expected":     { "x": 0, "y": 9.8, "z": 0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test -Y gravity",
@@ -45,7 +45,7 @@
       "illustration": "src/tests/accel_-y_gravity.png",
       "duration":     4,
       "expected":     { "x": 0, "y": -9.8, "z": 0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test +X acceleration",
@@ -53,7 +53,7 @@
       "illustration": "src/tests/accel_+x_acceleration.gif",
       "duration":     5,
       "expected":     { "x": 3.0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test -X acceleration",
@@ -61,6 +61,6 @@
       "illustration": "src/tests/accel_-x_acceleration.gif",
       "duration":     5,
       "expected":     { "x": -3.0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     }
 ]

--- a/sensor-tester/src/tests/ambientlightsensor.json
+++ b/sensor-tester/src/tests/ambientlightsensor.json
@@ -4,15 +4,17 @@
       "description":  "Test that sensor reports high illuminance when device is around a bright environment.",
       "illustration": "src/tests/als_day.png",
       "duration":     3,
-      "expected":     { "illuminance": {"min": 100} },
-      "epsilon":      0
+      "expected":     { "illuminance": 100 },
+      "epsilon":      0,
+      "comparison":   "min"
     },
     {
       "name":         "Test night mode",
       "description":  "Test that sensor reports very low illuminance when sensor is covered by hand.",
       "illustration": "src/tests/als_night.png",
       "duration":     3,
-      "expected":     { "illuminance": {"max": 5} },
-      "epsilon":      0
+      "expected":     { "illuminance": 5 },
+      "epsilon":      0,
+      "comparison":   "max"
     }
 ]

--- a/sensor-tester/src/tests/ambientlightsensor.json
+++ b/sensor-tester/src/tests/ambientlightsensor.json
@@ -5,8 +5,7 @@
       "illustration": "src/tests/als_day.png",
       "duration":     3,
       "expected":     { "illuminance": 100 },
-      "epsilon":      0,
-      "comparison":   "min"
+      "isEqual":      "(a, b) => a >= b"
     },
     {
       "name":         "Test night mode",
@@ -14,7 +13,6 @@
       "illustration": "src/tests/als_night.png",
       "duration":     3,
       "expected":     { "illuminance": 5 },
-      "epsilon":      0,
-      "comparison":   "max"
+      "isEqual":      "(a, b) => a <= b"
     }
 ]

--- a/sensor-tester/src/tests/gyroscope.json
+++ b/sensor-tester/src/tests/gyroscope.json
@@ -5,7 +5,7 @@
       "illustration": "src/tests/gyro-rest.png",
       "duration":     3,
       "expected":     { "x": 0, "y": 0, "z": 0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test +Z angular velocity",
@@ -13,7 +13,7 @@
       "illustration": "src/tests/gyro_+z.gif",
       "duration":     5,
       "expected":     { "z": 5.0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test -Z angular velocity",
@@ -21,7 +21,7 @@
       "illustration": "src/tests/gyro_-z.gif",
       "duration":     5,
       "expected":     { "z": -5.0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test +X angular velocity",
@@ -29,7 +29,7 @@
       "illustration": "src/tests/gyro_+x.gif",
       "duration":     5,
       "expected":     { "x": 5.0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test -X angular velocity",
@@ -37,7 +37,7 @@
       "illustration": "src/tests/gyro_-x.gif",
       "duration":     5,
       "expected":     { "x": -5.0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test +Y angular velocity",
@@ -45,7 +45,7 @@
       "illustration": "src/tests/gyro_+y.gif",
       "duration":     5,
       "expected":     { "y": 5.0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test -Y angular velocity",
@@ -53,6 +53,6 @@
       "illustration": "src/tests/gyro_-y.gif",
       "duration":     5,
       "expected":     { "y": -5.0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     }
 ]

--- a/sensor-tester/src/tests/linearaccelerationsensor-screen.json
+++ b/sensor-tester/src/tests/linearaccelerationsensor-screen.json
@@ -5,7 +5,7 @@
       "illustration": "src/tests/linaccel-rest.png",
       "duration":     3,
       "expected":     { "x": 0, "y": 0, "z": 0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test web page +X linear acceleration",
@@ -13,7 +13,7 @@
       "illustration": "src/tests/linaccel_+x.gif",
       "duration":     5,
       "expected":     { "x": 3.0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test web page -X linear acceleration",
@@ -21,6 +21,6 @@
       "illustration": "src/tests/linaccel_-x.gif",
       "duration":     5,
       "expected":     { "x": -3.0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     }
 ]

--- a/sensor-tester/src/tests/linearaccelerationsensor.json
+++ b/sensor-tester/src/tests/linearaccelerationsensor.json
@@ -5,7 +5,7 @@
       "illustration": "src/tests/linaccel-rest.png",
       "duration":     3,
       "expected":     { "x": 0, "y": 0, "z": 0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test +X linear acceleration",
@@ -13,7 +13,7 @@
       "illustration": "src/tests/linaccel_+x.gif",
       "duration":     5,
       "expected":     { "x": 3.0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test -X linear acceleration",
@@ -21,6 +21,6 @@
       "illustration": "src/tests/linaccel_-x.gif",
       "duration":     5,
       "expected":     { "x": -3.0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     }
 ]

--- a/sensor-tester/src/tests/magnetometer.json
+++ b/sensor-tester/src/tests/magnetometer.json
@@ -5,7 +5,7 @@
       "illustration": "src/tests/magnet_+X_north.png",
       "duration":     5,
       "expected":     { "y": 0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     },
     {
       "name":         "Test +Y points North",
@@ -13,6 +13,6 @@
       "illustration": "src/tests/magnet_+Y_north.png",
       "duration":     5,
       "expected":     { "x": 0 },
-      "epsilon":      1
+      "isEqual":      "(a, b) => Math.abs(a - b) < 1"
     }
 ]

--- a/sensor-tester/src/tests/relativeorientationsensor.json
+++ b/sensor-tester/src/tests/relativeorientationsensor.json
@@ -1,7 +1,7 @@
 [
     {
       "name":         "Test sensor at first acquisition",
-      "description":  "Test that sensor reports quaternion approach to '[0, 0, 0, 1.0]' at its first acquisition when device is at rest on a leveled surface.",
+      "description":  "Test that sensor reports quaternion approach to '[0, 0, 0, 1.0]' or '[0, 0, 0, -1.0]' at its first acquisition when device is at rest on a leveled surface.",
       "illustration": "src/tests/absoluteorien_+Y_north.png",
       "duration":     3,
       "expected":     { "quaternion": { "abs": [0, 0, 0, 1] } },

--- a/sensor-tester/src/tests/relativeorientationsensor.json
+++ b/sensor-tester/src/tests/relativeorientationsensor.json
@@ -4,8 +4,9 @@
       "description":  "Test that sensor reports quaternion approach to '[0, 0, 0, 1.0]' or '[0, 0, 0, -1.0]' at its first acquisition when device is at rest on a leveled surface.",
       "illustration": "src/tests/absoluteorien_+Y_north.png",
       "duration":     3,
-      "expected":     { "quaternion": { "abs": [0, 0, 0, 1] } },
-      "epsilon":      0.1
+      "expected":     { "quaternion": [0, 0, 0, 1] },
+      "epsilon":      0.1,
+      "comparison":   "absolute"
     },
     {
       "name":         "Test 90 degrees rotation around Z",

--- a/sensor-tester/src/tests/relativeorientationsensor.json
+++ b/sensor-tester/src/tests/relativeorientationsensor.json
@@ -1,0 +1,10 @@
+[
+    {
+      "name":         "Test at sensor reading first acquisition",
+      "description":  "Test that sensor reports quaternion approach to '[0, 0, 0, 1.0]' at its first acquisition when device is at rest on a leveled surface.",
+      "illustration": "src/tests/absoluteorien_+Y_north.png",
+      "duration":     3,
+      "expected":     { "quaternion": [0, 0, 0, 1.0] },
+      "epsilon":      0.1
+    }
+]

--- a/sensor-tester/src/tests/relativeorientationsensor.json
+++ b/sensor-tester/src/tests/relativeorientationsensor.json
@@ -5,8 +5,7 @@
       "illustration": "src/tests/absoluteorien_+Y_north.png",
       "duration":     3,
       "expected":     { "quaternion": [0, 0, 0, 1] },
-      "epsilon":      0.1,
-      "comparison":   "absolute"
+      "isEqual":      "(a, b) => Math.abs(Math.abs(a) - Math.abs(b)) < 0.1"
     },
     {
       "name":         "Test 90 degrees rotation around Z",
@@ -14,6 +13,6 @@
       "illustration": "src/tests/absoluteorien_+Y_north.png",
       "duration":     6,
       "expected":     "none",
-      "epsilon":      0.1
+      "isEqual":      "(a, b) => Math.abs(Math.abs(a) - Math.abs(b)) < 0.1"
     }
 ]

--- a/sensor-tester/src/tests/relativeorientationsensor.json
+++ b/sensor-tester/src/tests/relativeorientationsensor.json
@@ -1,10 +1,18 @@
 [
     {
-      "name":         "Test at sensor reading first acquisition",
+      "name":         "Test sensor at first acquisition",
       "description":  "Test that sensor reports quaternion approach to '[0, 0, 0, 1.0]' at its first acquisition when device is at rest on a leveled surface.",
       "illustration": "src/tests/absoluteorien_+Y_north.png",
       "duration":     3,
-      "expected":     { "quaternion": [0, 0, 0, 1.0] },
+      "expected":     { "quaternion": { "abs": [0, 0, 0, 1] } },
+      "epsilon":      0.1
+    },
+    {
+      "name":         "Test 90 degrees rotation around Z",
+      "description":  "Test that sensor rotation is measured correctly when rotate device 90 degrees clockwise from its rest state(keep more than 1s) on a leveled surface.",
+      "illustration": "src/tests/absoluteorien_+Y_north.png",
+      "duration":     6,
+      "expected":     "none",
       "epsilon":      0.1
     }
 ]


### PR DESCRIPTION
Add one test for RelativeOrientationSensor to check sensor reports quaternion approach to '[0, 0, 0, 1.0]' at its first acquisition, which is mentioned in https://blog.mide.com/quaternions-for-orientation.

@alexshalamov, PTAL and please tell me if you have more ideas about testing for RelativeOrientationSensor.