### PR TITLE
Move security information to a separate SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,4 +141,7 @@ If you are developing for mobile devices,set up
 for your local server, and you are good to go!
 
 ## Reporting a security issue
-If you have information about a security issue or vulnerability with an Intel-maintained open source project on https://github.com/intel, please send an e-mail to secure-opensource@intel.com. Encrypt sensitive information using our PGP public key. For issues related to Intel products, please visit https://security-center.intel.com.
+See Intel's [Security Center](https://www.intel.com/content/www/us/en/security-center/default.html)
+for information on how to report a potential security issue or vulnerability.
+
+See also: [Security Policy](SECURITY.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Report a Vulnerability
+
+Please report security issues or vulnerabilities to the [Intel Security Center].
+
+For more information on how Intel works to resolve security issues, see
+[Vulnerability Handling Guidelines].
+
+[Intel Security Center]:https://www.intel.com/security
+
+[Vulnerability Handling Guidelines]:https://www.intel.com/content/www/us/en/security-center/vulnerability-handling-guidelines.html


### PR DESCRIPTION
This follows current best practices as described in
https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository

The contents have also been updated to match what other projects in
the same GitHub organization use, such as
intel/intel-extension-for-pytorch and intel/scikit-learn-intelex.
